### PR TITLE
added body size

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -46,7 +46,7 @@ It would be impossible to list everything staff can do to create a more welcomin
 To help colleagues understand the kinds of behaviors that are illegal or run counter to the culture we seek to foster, we've listed below actions that are unacceptable within our community:
 
  * Violence, threats of violence, or violent language directed against another person.
- * Unwelcome verbal or written comment or physical conduct based on race, religion, color, sex (with or without sexual conduct and including pregnancy and sexual orientation involving transgender status/gender identity, and sex-stereotyping), national origin, age, disability, genetic information, sexual orientation, gender identity, parental status, marital status, or political affiliation.
+ * Unwelcome verbal or written comment or physical conduct based on race, religion, color, body size, sex (with or without sexual conduct and including pregnancy and sexual orientation involving transgender status/gender identity, and sex-stereotyping), national origin, age, disability, genetic information, sexual orientation, gender identity, parental status, marital status, or political affiliation.
  * Posting or displaying sexually explicit or violent material.
  * Posting or threatening to post other people's personally identifying information ("doxing").
  * Inappropriate photography or recording.


### PR DESCRIPTION
I would add to this list unwanted verbal or written comment or physical conduct based on body size. Prejudice and harassment against people in larger bodies is incredibly common in our society. For example, a recent study found that body size is the most prevalent reason that kids get bullied in school. ([https://onlinelibrary.wiley.com/doi/full/10.1111/ijpo.12051](https://gcc02.safelinks.protection.outlook.com/?url=https%3A%2F%2Fonlinelibrary.wiley.com%2Fdoi%2Ffull%2F10.1111%2Fijpo.12051&data=05%7C01%7Cmargaret.m.mcadam%40nasa.gov%7Cd30bdea86a8f42877d6d08db16a3aed3%7C7005d45845be48ae8140d43da96dd17b%7C0%7C0%7C638128664483790175%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000%7C%7C%7C&sdata=Tr4QLblxl25qDdaXS0pZh4%2F1%2F%2FGq3G99HGEJ8eVRusE%3D&reserved=0)). And yet, most anti-bullying campaigns do not address, provide remedies or training against fatphobic bullying. Adding this clause to the TOPS code of conduct would support our community in providing a rare but very needed guardrail against size-based harassment. Here is my suggested addition in context: 

“Unwelcome verbal or written comment or physical conduct based on race, religion, color, **body size**, sex (with or without sexual conduct and including pregnancy and sexual orientation involving transgender status/gender identity, and sex-stereotyping), national origin, age, disability, genetic information, sexual orientation, gender identity, parental status, marital status, or political affiliation.”
